### PR TITLE
[codex] Fix false positives for JsonRpcErrorCode comparisons

### DIFF
--- a/src/linter/rules/error-contract-rules.ts
+++ b/src/linter/rules/error-contract-rules.ts
@@ -316,8 +316,8 @@ export function lintErrorContractConformance(
 
   const observed = new Set<JsonRpcErrorCode>();
 
-  // Direct references: `JsonRpcErrorCode.NotFound`
-  for (const m of cleaned.matchAll(/JsonRpcErrorCode\.(\w+)/g)) {
+  // Direct throws: `throw new McpError(JsonRpcErrorCode.NotFound, ...)`
+  for (const m of cleaned.matchAll(/\bthrow\s+new\s+McpError\s*\(\s*JsonRpcErrorCode\.(\w+)/g)) {
     const value = m[1] ? CODE_NAME_TO_VALUE[m[1]] : undefined;
     if (value !== undefined) observed.add(value);
   }

--- a/tests/unit/linter/error-contract-rules.test.ts
+++ b/tests/unit/linter/error-contract-rules.test.ts
@@ -383,6 +383,30 @@ describe('lintErrorContractConformance', () => {
       );
       expect(d).toEqual([]);
     });
+
+    it('does not treat JsonRpcErrorCode comparisons as direct throws', () => {
+      const handler = new Function(
+        `return async () => {
+          try {
+            throw new Error("boom");
+          } catch (err) {
+            if (err instanceof McpError && err.code === JsonRpcErrorCode.NotFound) {
+              throw ctx.fail("not_found", "Not found");
+            }
+            throw err;
+          }
+        }`,
+      )();
+      const d = lintErrorContractConformance(
+        {
+          handler,
+          errors: [{ code: JsonRpcErrorCode.NotFound, reason: 'not_found', when: 'no match' }],
+        },
+        'tool',
+        'x',
+      );
+      expect(d).toEqual([]);
+    });
   });
 
   it('produces no diagnostics for a clean handler that uses ctx.fail', () => {


### PR DESCRIPTION
## Summary
- scope `JsonRpcErrorCode.X` detection in `lintErrorContractConformance` to `throw new McpError(...)` sites instead of any enum reference in the handler source
- add a regression test covering `err.code === JsonRpcErrorCode.NotFound` followed by `ctx.fail(...)`

## Root cause
The conformance heuristic treated every `JsonRpcErrorCode.X` token as a direct throw, so comparison logic inside catch/switch flows triggered `error-contract-prefer-fail` even when the handler routed correctly through `ctx.fail(...)`.

## Validation
- `bunx vitest run --project unit tests/unit/linter/error-contract-rules.test.ts`
- `bunx vitest run --project unit tests/unit/linter/*.test.ts`

Closes #191.
