### PR TITLE
fix(scheduler): catch missing node-cron import to prevent crash-loop

### DIFF
--- a/src/utils/scheduling/scheduler.ts
+++ b/src/utils/scheduling/scheduler.ts
@@ -35,7 +35,14 @@ async function loadCron(): Promise<typeof import('node-cron')> {
     );
   }
   if (!cronModulePromise) {
-    cronModulePromise = import('node-cron');
+    cronModulePromise = import('node-cron').catch((err: unknown) => {
+      cronModulePromise = null;
+      throw configurationError(
+        'SchedulerService requires the "node-cron" peer dependency. Install it with: npm install node-cron',
+        undefined,
+        { cause: err instanceof Error ? err : new Error(String(err)) },
+      );
+    });
   }
   return await cronModulePromise;
 }


### PR DESCRIPTION
## Problem

When `node-cron` is not installed as a peer dependency, the bare `import(node-cron)` in `loadCron()` throws a raw `Cannot find package` error. This propagates out of `SchedulerService.schedule()` and **crash-loops the entire server at startup**, not just the scheduler.

Fixes #200

## Solution

Wrap the dynamic `import(node-cron)` in `.catch()` so that a missing peer dependency surfaces a clear `ConfigurationError` with an actionable install hint:

> SchedulerService requires the "node-cron" peer dependency. Install it with: npm install node-cron

- Reset `cronModulePromise` to `null` on failure so a subsequent call can retry after the dependency is installed
- Chain the original error as `{ cause }` for debugging