### PR TITLE
docs(outlineOnOverflow): align JSDoc and skill with ZodObject output constraint

### DIFF
--- a/skills/techniques/references/outline-on-overflow.md
+++ b/skills/techniques/references/outline-on-overflow.md
@@ -20,9 +20,9 @@ This is distinct from the other two overflow shapes:
 
 **Never truncate to fit a budget.** When a payload is too big, return a complete, honest outline of what's available plus how to retrieve it — identically on `content[]` and `structuredContent`.
 
-## The shape — a discriminated-union `output`
+## The shape — a flat `output` object with a `kind` discriminator
 
-The outline is the payload the agent acts on, so it lands in the **main body** (`structuredContent` + `content[]`), as a variant of the tool's own `output`. Not the enrichment block — enrichment is *additive* (`output.extend(...)` merged after `output.parse(result)`), so it can add fields to the fat document but never replace it. Not a post-hoc framework swap either — that would emit a `structuredContent` shape the advertised `outputSchema` (`tools/list`) doesn't describe. A discriminated-union variant is the only placement that replaces the payload, is advertised honestly, and gets `format()`-parity for free.
+The outline is the payload the agent acts on, so it lands in the **main body** (`structuredContent` + `content[]`), as a variant of the tool's own `output`. Not the enrichment block — enrichment is *additive* (`output.extend(...)` merged after `output.parse(result)`), so it can add fields to the fat document but never replace it. Not a post-hoc framework swap either — that would emit a `structuredContent` shape the advertised `outputSchema` (`tools/list`) doesn't describe. A tool's `output` must be a `ZodObject`, so model the `full | outline` variants as a flat object with a `kind` discriminator and presence-based optional arms — not `z.discriminatedUnion`.
 
 ```ts
 import { tool, z } from '@cyanheads/mcp-ts-core';
@@ -44,10 +44,14 @@ export const getLabel = tool('get_label', {
       .optional()
       .describe('Sections to return. Omit for the full label (or an outline if it overflows).'),
   }),
-  output: z.discriminatedUnion('kind', [
-    FullLabel.extend({ kind: z.literal('full') }),
-    OUTLINE_VARIANT,
-  ]),
+  output: z.object({
+    kind: z.enum(['full', 'outline']),
+    // full-mode arms (present when kind === 'full')
+    // …full-payload fields, each .optional()…
+    // outline-mode arms (present when kind === 'outline')
+    sections: OUTLINE_VARIANT.shape.sections.optional(),
+    notice: z.string().optional(),
+  }),
   format: (r) => (r.kind === 'outline' ? formatOutline(r) : renderLabel(r)),
   async handler(input) {
     const doc = await fetchLabel(input.query); // deterministic from query
@@ -60,7 +64,7 @@ export const getLabel = tool('get_label', {
 });
 ```
 
-`format()`-parity is enforced **per branch** — the linter walks each discriminated-union arm separately, so both `full` and `outline` must render. `formatOutline` is the shipped renderer for the `outline` arm; you supply the `full` renderer. That keeps the two client surfaces in lockstep with no extra work.
+`format()`-parity is enforced on the flat `output` object — `format()` renders each field when present, so both `full` and `outline` arms stay in lockstep across `content[]` and `structuredContent`. `formatOutline` is the shipped renderer for the `outline` arm; you supply the `full` renderer.
 
 ## The helper
 
@@ -69,7 +73,7 @@ export const getLabel = tool('get_label', {
 | Export | Purpose |
 |:--|:--|
 | `outlineOnOverflow(doc, options?)` | Returns `{ kind: 'full', ...doc }` under budget (or with `< 2` sections), else `{ kind: 'outline', sections, notice }`. |
-| `OUTLINE_VARIANT` | The reusable `outline`-arm Zod schema for your discriminated-union `output`. |
+| `OUTLINE_VARIANT` | The reusable `outline`-arm Zod schema — spread its `sections` and `notice` fields into your flat `output` object. |
 | `selectSections(doc, want, { alwaysKeep })` | Projects the document to requested keys plus always-kept metadata. The selection-path counterpart. |
 | `formatOutline(outline)` | Renders the outline to `content[]` for `format()`. |
 | `DEFAULT_OUTLINE_BUDGET_BYTES` | The default budget (`24_000`) when `options.budget` is omitted. |

--- a/src/utils/overflow/outlineOnOverflow.ts
+++ b/src/utils/overflow/outlineOnOverflow.ts
@@ -27,14 +27,21 @@ export interface SectionMeta {
 }
 
 /**
- * Reusable outline arm for a tool's discriminated-union `output`. Pair it with
- * the tool's full-payload schema so the parity linter validates each branch:
+ * Reusable outline fields for a tool's flat `output` object. A tool's `output`
+ * must be a `ZodObject` (not a discriminated union), so declare `kind` plus
+ * presence-based optional arms — full-payload fields when `kind === 'full'`,
+ * `sections` and `notice` when `kind === 'outline'`:
  *
  * ```ts
- * output: z.discriminatedUnion('kind', [
- *   FullLabel.extend({ kind: z.literal('full') }),
- *   OUTLINE_VARIANT,
- * ]),
+ * output: z.object({
+ *   kind: z.enum(['full', 'outline']),
+ *   // full-mode arms (present when kind === 'full')
+ *   id: z.string().optional(),
+ *   body: z.string().optional(),
+ *   // outline-mode arms (present when kind === 'outline')
+ *   sections: OUTLINE_VARIANT.shape.sections.optional(),
+ *   notice: z.string().optional(),
+ * }),
  * ```
  */
 export const OUTLINE_VARIANT = z.object({
@@ -97,8 +104,8 @@ function defaultNotice(sections: SectionMeta[]): string {
 
 /**
  * Returns the document whole when it fits the budget, or a section outline when
- * it overflows. The caller spreads the result into a discriminated-union `output`
- * keyed on `kind` ({@link OUTLINE_VARIANT} supplies the outline arm).
+ * it overflows. The caller spreads the result into a flat `output` object keyed
+ * on `kind` (use {@link OUTLINE_VARIANT} fields for the outline arms).
  *
  * Single-entry short-circuit: a document with fewer than two sections is returned
  * whole even when over budget — an outline of one section would cost a round-trip


### PR DESCRIPTION
## Summary

Replace `z.discriminatedUnion` examples in the outline-on-overflow documentation with the flat `z.object` pattern that `tool()` actually accepts.

## Motivation

`tool()` requires `output` to be a `ZodObject` (`tool-rules.ts` enforces `schema-is-object`). The `OUTLINE_VARIANT` JSDoc and the `outline-on-overflow` techniques reference both showed `z.discriminatedUnion('kind', [...])`, which fails `bun run lint:mcp` and breaks at registration when enrichment is declared. Issue #249 documents the correct flat-object pattern; this PR aligns the guidance with that constraint.

## Changes

- **`src/utils/overflow/outlineOnOverflow.ts`**: Rewrite `OUTLINE_VARIANT` JSDoc example and update `outlineOnOverflow` comment to describe flat `output` objects with presence-based optional arms.
- **`skills/techniques/references/outline-on-overflow.md`**: Update section title, example `output` declaration, format-parity explanation, and `OUTLINE_VARIANT` table row.

## Tests

- `bun run lint:mcp` — pass
- `bun test tests/unit/utils/overflow/outlineOnOverflow.test.ts` — 13 pass

## Notes

- Docs-only change; no runtime behavior modified.
- `skills/add-tool/SKILL.md` and `skills/design-mcp-server/SKILL.md` still mention discriminated-union output in passing — left for a follow-up to keep this PR scoped to #249.

Fixes #249